### PR TITLE
ci: add mirrorchyan uploading

### DIFF
--- a/.github/workflows/mirrorchyan_release.yml
+++ b/.github/workflows/mirrorchyan_release.yml
@@ -1,0 +1,38 @@
+name: mirrorchyan_release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        default: ''
+        required: false
+  release:
+    types: [published]
+
+jobs:
+  mirrorchyan:
+    if: ${{ github.repository_owner == 'NotZoruak' }}
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: win
+            arch: x86_64
+            filename: 'MATR-*.zip'
+
+    steps:
+      - uses: MirrorChyan/uploading-action@v1
+        with:
+          filetype: latest-release
+          filename: ${{ matrix.filename }}
+          mirrorchyan_rid: MATR
+          tag: ${{ inputs.tag }}
+
+          os: ${{ matrix.os }}
+          arch: ${{ matrix.arch }}
+
+          owner: NotZoruak
+          repo: MATR
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          upload_token: ${{ secrets.MirrorChyanUploadToken }}

--- a/.github/workflows/mirrorchyan_release_note.yml
+++ b/.github/workflows/mirrorchyan_release_note.yml
@@ -1,0 +1,27 @@
+name: mirrorchyan_release_note
+
+on:
+  workflow_dispatch:
+    inputs:
+        tag:
+            default: ''
+            required: false
+  release:
+    types: [edited]
+
+jobs:
+  mirrorchyan:
+    if: ${{ github.repository_owner == 'NotZoruak' }}
+    runs-on: macos-latest
+
+    steps:
+      - id: uploading
+        uses: MirrorChyan/release-note-action@v1
+        with:
+          mirrorchyan_rid: MATR
+          version_name: ${{ inputs.tag }}
+
+          owner: NotZoruak
+          repo: MATR
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          upload_token: ${{ secrets.MirrorChyanUploadToken }}

--- a/interface.json
+++ b/interface.json
@@ -1,6 +1,8 @@
 {
   "name": "MATR",
   "version": "v0.7.0",
+  "mirrorchyan_rid": "MATR",
+  "mirrorchyan_multiplatform": true,
   "icon": "resource/logo/MATR.ico",
   "custom_title": "MATR v0.7.0 | 刀剑乱舞小助手",
   "Github": "https://github.com/NotZoruak/MATR",


### PR DESCRIPTION
接入 Mirror酱(MirrorChyan) 第三方分发服务。

- 新增 mirrorchyan_release / mirrorchyan_release_note workflows
- 适配手动上传 release 包（监听 release published/edited）
- interface.json 添加 mirrorchyan_rid 与 mirrorchyan_multiplatform
- RID: MATR，上传 MATR-*.zip（win/x86_64）
