### PR TITLE
feat: 支持 macOS (Apple Silicon) 构建与运行

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ desktop.ini
 # 打包产物
 /MATR-*.zip
 /MATR-*/
+/MATR.app/
 /_temp_zip/
 
 # Codex 工作文件(不随仓库分发)

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ desktop.ini
 
 # 打包产物
 /MATR-*.zip
+/MATR-*/
 /_temp_zip/
 
 # Codex 工作文件(不随仓库分发)

--- a/_src/MFAAvalonia.Desktop/MFAAvalonia.Desktop.csproj
+++ b/_src/MFAAvalonia.Desktop/MFAAvalonia.Desktop.csproj
@@ -1,14 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <OutputType>WinExe</OutputType>
+        <!-- WinExe 抑制 Windows 上的控制台窗口；非 Windows 上无该子系统概念，用 Exe 更贴切 -->
+        <OutputType Condition="'$(OS)' == 'Windows_NT'">WinExe</OutputType>
+        <OutputType Condition="'$(OS)' != 'Windows_NT'">Exe</OutputType>
         <AssemblyName>MATR</AssemblyName>
         <OutputName>MATR</OutputName>
         <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
-        <Platforms>x64</Platforms>
-        <ApplicationManifest>app.manifest</ApplicationManifest>
-        <ApplicationIcon>..\MFAAvalonia\Assets\logo.ico</ApplicationIcon>
+        <!-- 实际以 RID 发布；声明 AnyCPU 以匹配默认 Platform，避免 osx/linux 构建被 x64-only 限制 -->
+        <Platforms>AnyCPU;x64</Platforms>
+        <!-- app.manifest 与 .ico 均为 Windows 专属，非 Windows 忽略；显式条件化保持整洁 -->
+        <ApplicationManifest Condition="'$(OS)' == 'Windows_NT'">app.manifest</ApplicationManifest>
+        <ApplicationIcon Condition="'$(OS)' == 'Windows_NT'">..\MFAAvalonia\Assets\logo.ico</ApplicationIcon>
         <CETCompat>false</CETCompat>
     </PropertyGroup>
 

--- a/_src/MFAAvalonia.Desktop/MFAAvalonia.Desktop.csproj
+++ b/_src/MFAAvalonia.Desktop/MFAAvalonia.Desktop.csproj
@@ -31,6 +31,10 @@
         <MaaAgentBinaryPath>libs/MaaAgentBinary</MaaAgentBinaryPath>
         <BeautyLibsDir>.;./runtimes/libs</BeautyLibsDir>
         <BeautyOnPublishOnly>True</BeautyOnPublishOnly>
+        <!-- NetBeauty 的 BeautyLibsDir 用 ';' 分隔目录，在非 Windows 的 /bin/sh 下 ';' 会被当作命令分隔符
+             导致 nbeauty2 调用失败（exit 127）。NetBeauty 仅为整理输出目录的可选优化，非运行必需，
+             故在非 Windows 上禁用；代理路径由 MaaProcessor.ResolveAgentBinaryPath 回退查找 libs/ 或根目录。 -->
+        <DisableBeauty Condition="'$(OS)' != 'Windows_NT'">True</DisableBeauty>
         <DebugType>none</DebugType>
         <DebugSymbols>false</DebugSymbols>
     </PropertyGroup>

--- a/_src/MFAAvalonia.Desktop/Program.cs
+++ b/_src/MFAAvalonia.Desktop/Program.cs
@@ -42,7 +42,10 @@ sealed class Program
         try
         {
             var projectDir = AppDomain.CurrentDomain.BaseDirectory;
-            var pythonExe = Path.Combine(projectDir, "venv", "Scripts", "python.exe");
+            // Python venv 布局因平台而异：Windows 为 venv/Scripts/python.exe，类 Unix 为 venv/bin/python
+            var pythonExe = OperatingSystem.IsWindows()
+                ? Path.Combine(projectDir, "venv", "Scripts", "python.exe")
+                : Path.Combine(projectDir, "venv", "bin", "python");
             var scriptPath = Path.Combine(projectDir, "matr", "pipeline_gen.py");
             if (File.Exists(pythonExe) && File.Exists(scriptPath))
             {

--- a/_src/MFAAvalonia.Desktop/Program.cs
+++ b/_src/MFAAvalonia.Desktop/Program.cs
@@ -1,6 +1,8 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Media;
+using Avalonia.Media.Fonts;
 using Avalonia.Threading;
 using MaaFramework.Binding;
 using MFAAvalonia;
@@ -249,6 +251,18 @@ sealed class Program
         return AppBuilder.Configure<App>()
             .UsePlatformDetect()
             .WithInterFont()
+            // 跨平台 CJK 字体回退：部分控件（如 SukiUI 默认字体回退到仅含拉丁字形的 Quicksand）
+            // 在缺少 CJK 回退的平台（如 macOS）会把中文显示为方框（豆腐块）。此处补充系统级回退，
+            // 不存在的字体会被自动跳过：Windows=Microsoft YaHei，macOS=PingFang SC，Linux=Noto Sans CJK SC。
+            .With(new FontManagerOptions
+            {
+                FontFallbacks =
+                [
+                    new FontFallback { FontFamily = new FontFamily("Microsoft YaHei") },
+                    new FontFallback { FontFamily = new FontFamily("PingFang SC") },
+                    new FontFallback { FontFamily = new FontFamily("Noto Sans CJK SC") },
+                ],
+            })
             .LogToTrace();
     }
 

--- a/_src/MFAAvalonia/Extensions/MaaFW/MaaProcessor.cs
+++ b/_src/MFAAvalonia/Extensions/MaaFW/MaaProcessor.cs
@@ -1965,6 +1965,28 @@ public class MaaProcessor
         LoggerHelper.Error($"初始化控制器失败：title={title}, message={message}, reason={e.Message}", e);
     }
 
+    /// <summary>
+    /// 解析 MaaAgentBinary（minitouch/maatouch 等设备端代理）所在目录。
+    /// Windows 发布经 NetBeauty 将其归置到 runtimes/libs 下；非 Windows（如 macOS）
+    /// 不使用 NetBeauty，代理会留在 libs 或发布根目录，故按优先级回退查找。
+    /// </summary>
+    private static string ResolveAgentBinaryPath()
+    {
+        var candidates = new[]
+        {
+            Path.Combine(AppPaths.InstallRoot, "runtimes", "libs", "MaaAgentBinary"),
+            Path.Combine(AppPaths.InstallRoot, "libs", "MaaAgentBinary"),
+            Path.Combine(AppPaths.InstallRoot, "MaaAgentBinary"),
+        };
+        foreach (var path in candidates)
+        {
+            if (Directory.Exists(path))
+                return path;
+        }
+        // 均不存在时返回原默认路径，保持与旧行为一致（由 MaaFramework 报错提示）
+        return candidates[0];
+    }
+
     private MaaController InitializeController(MaaControllerTypes controllerType, bool logConfig)
     {
         ConnectToMAA(logConfig);
@@ -1996,7 +2018,7 @@ public class MaaProcessor
                     Config.AdbDevice.AdbSerial,
                     Config.AdbDevice.ScreenCap, Config.AdbDevice.Input,
                     !string.IsNullOrWhiteSpace(Config.AdbDevice.Config) ? Config.AdbDevice.Config : "{}",
-                    Path.Combine(AppPaths.InstallRoot, "runtimes", "libs", "MaaAgentBinary")
+                    ResolveAgentBinaryPath()
                 );
 
             case MaaControllerTypes.PlayCover:

--- a/_src/MFAAvalonia/Helper/Instances.cs
+++ b/_src/MFAAvalonia/Helper/Instances.cs
@@ -651,7 +651,7 @@ public static partial class Instances
                 if (IsResolved<VersionUpdateSettingsUserControlModel>())
                 {
                     var version = VersionUpdateSettingsUserControlModel;
-                    version.DownloadSourceIndex = ConfigurationManager.Current.GetValue(ConfigurationKeys.DownloadSourceIndex, 1);
+                    version.DownloadSourceIndex = ConfigurationManager.Current.GetValue(ConfigurationKeys.DownloadSourceIndex, 0);
                     version.UIUpdateChannelIndex = ConfigurationManager.Current.GetValue(ConfigurationKeys.UIUpdateChannelIndex, 2);
                     version.ResourceUpdateChannelIndex = ConfigurationManager.Current.GetValue(ConfigurationKeys.ResourceUpdateChannelIndex, 2);
                     version.GitHubToken = SimpleEncryptionHelper.Decrypt(ConfigurationManager.Current.GetValue(ConfigurationKeys.GitHubToken, string.Empty));

--- a/_src/MFAAvalonia/ViewModels/UsersControls/Settings/VersionUpdateSettingsUserControlModel.cs
+++ b/_src/MFAAvalonia/ViewModels/UsersControls/Settings/VersionUpdateSettingsUserControlModel.cs
@@ -195,7 +195,7 @@ public partial class VersionUpdateSettingsUserControlModel : ViewModelBase
         new(LangKeys.MirrorChyan),
     ];
 
-    [ObservableProperty] private int _downloadSourceIndex = ConfigurationManager.Current.GetValue(ConfigurationKeys.DownloadSourceIndex, 1);
+    [ObservableProperty] private int _downloadSourceIndex = ConfigurationManager.Current.GetValue(ConfigurationKeys.DownloadSourceIndex, 0);
 
     partial void OnDownloadSourceIndexChanged(int value)
     {

--- a/_src/MFAAvalonia/Views/Pages/TaskQueueView.axaml
+++ b/_src/MFAAvalonia/Views/Pages/TaskQueueView.axaml
@@ -1013,13 +1013,11 @@
                                 IsVisible="{Binding ShowSettings}"
                                 Spacing="8">
                         <RadioButton FontSize="11" FontWeight="Bold"
-                                     Classes="Inner"
                                      IsChecked="{Binding IsCommon}"
                                      GroupName="SettingA">
                             <TextBlock Text="{markup:I18n {x:Static helper:LangKeys.CommonSetting}}" />
                         </RadioButton>
                         <RadioButton FontSize="11" FontWeight="Bold"
-                                     Classes="Inner"
                                      GroupName="SettingA"
                                      IsChecked="{calcBinding:Binding '!IsCommon'}">
                             <TextBlock Text="全局" />

--- a/tools/pack_mac.sh
+++ b/tools/pack_mac.sh
@@ -69,6 +69,21 @@ stage_payload() {
     chmod +x "$dest/MATR" 2>/dev/null || true
 }
 
+# 从人类可读版本号推导合法的 macOS Bundle 版本字段。
+# CFBundleShortVersionString / CFBundleVersion 只接受"点分非负整数"（如 0.12.2），
+# 因此去掉前导 v、预发布后缀（-beta / -rc 等）与构建元数据；非法则回退到 0.0.0。
+sanitize_version() {
+    local v="$1"
+    v="${v#[vV]}"      # 去掉前导 v/V（v0.12.2 → 0.12.2）
+    v="${v%%-*}"       # 去掉 -beta / -rc1 等预发布后缀
+    v="${v%%+*}"       # 去掉 +build 构建元数据
+    if [[ "$v" =~ ^[0-9]+(\.[0-9]+){0,2}$ ]]; then
+        printf '%s' "$v"
+    else
+        printf '0.0.0'  # dev 等非数字版本回退到合法占位值
+    fi
+}
+
 # 由 PNG 生成 .icns（缺 logo 时跳过）
 make_icns() {
     local src="$1" dst="$2"
@@ -95,6 +110,8 @@ else
     rm -rf "$APPDIR"
     mkdir -p "$APPDIR/Contents/MacOS" "$APPDIR/Contents/Resources"
     stage_payload "$APPDIR/Contents/MacOS"
+    PLIST_VERSION="$(sanitize_version "$VERSION")"
+    echo "    Bundle 版本：${PLIST_VERSION}（源版本：${VERSION}）"
     if make_icns "$LOGO" "$APPDIR/Contents/Resources/MATR.icns"; then
         ICON_LINE="    <key>CFBundleIconFile</key><string>MATR</string>"
     else
@@ -108,8 +125,8 @@ else
     <key>CFBundleName</key><string>MATR</string>
     <key>CFBundleDisplayName</key><string>MATR</string>
     <key>CFBundleIdentifier</key><string>com.notzoruak.matr</string>
-    <key>CFBundleVersion</key><string>${VERSION}</string>
-    <key>CFBundleShortVersionString</key><string>${VERSION}</string>
+    <key>CFBundleVersion</key><string>${PLIST_VERSION}</string>
+    <key>CFBundleShortVersionString</key><string>${PLIST_VERSION}</string>
     <key>CFBundleExecutable</key><string>MATR</string>
 ${ICON_LINE}
     <key>CFBundlePackageType</key><string>APPL</string>

--- a/tools/pack_mac.sh
+++ b/tools/pack_mac.sh
@@ -2,13 +2,16 @@
 #
 # macOS 打包脚本（tools/pack.ps1 的 macOS 等价物）。
 # 将 `dotnet publish` 产物与游戏资源（assets/interface.json + assets/resource）
-# 组装成一个可直接运行的文件夹 MATR-<版本>-<RID>/，内含原生可执行文件 ./MATR。
+# 组装成可运行的输出：
+#   - 默认：文件夹 MATR-<版本>-<RID>/（内含原生可执行文件 ./MATR）
+#   - --app：双击即用的 MATR.app 应用包（自动自包含，用户无需安装 .NET）
 #
 # 用法：
-#   tools/pack_mac.sh [版本] [--self-contained] [--zip]
-#     版本            输出目录/压缩包名中的版本号（默认 dev）
+#   tools/pack_mac.sh [版本] [--self-contained] [--app] [--zip]
+#     版本            输出名中的版本号（默认 dev）
 #     --self-contained 打包自包含 .NET 运行时（免装/免设 DOTNET_ROOT，体积更大）
-#     --zip           额外产出 MATR-<版本>-<RID>.zip
+#     --app           产出 MATR.app（隐含 --self-contained，除非显式框架依赖）
+#     --zip           额外产出压缩包
 # 环境变量：
 #   RID     目标运行时（默认 osx-arm64，可设 osx-x64）
 #   DOTNET  dotnet 可执行文件（默认 dotnet；SDK 装在 ~/.dotnet 时设 DOTNET="$HOME/.dotnet/dotnet"）
@@ -17,15 +20,23 @@ set -euo pipefail
 
 VERSION="dev"
 SELF_CONTAINED=false
+SELF_CONTAINED_SET=false
+APP=false
 ZIP=false
 for arg in "$@"; do
     case "$arg" in
-        --self-contained) SELF_CONTAINED=true ;;
+        --self-contained) SELF_CONTAINED=true; SELF_CONTAINED_SET=true ;;
+        --framework-dependent) SELF_CONTAINED=false; SELF_CONTAINED_SET=true ;;
+        --app) APP=true ;;
         --zip) ZIP=true ;;
         -*) echo "未知选项：$arg" >&2; exit 2 ;;
         *) VERSION="$arg" ;;
     esac
 done
+# .app 面向"下载即用"，默认自包含（除非用户显式选择框架依赖）
+if [ "$APP" = true ] && [ "$SELF_CONTAINED_SET" = false ]; then
+    SELF_CONTAINED=true
+fi
 
 RID="${RID:-osx-arm64}"
 DOTNET="${DOTNET:-dotnet}"
@@ -33,6 +44,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CSPROJ="$ROOT/_src/MFAAvalonia.Desktop/MFAAvalonia.Desktop.csproj"
 PUBLISH_DIR="$ROOT/_src/bin/AnyCPU/Release/$RID/publish"
 OUT="$ROOT/MATR-$VERSION-$RID"
+LOGO="$ROOT/assets/resource/logo/MATR.png"
 
 command -v "$DOTNET" >/dev/null 2>&1 || { echo "找不到 dotnet（可用 DOTNET=/path/to/dotnet 指定）" >&2; exit 1; }
 
@@ -40,39 +52,97 @@ echo "==> 发布 ${RID}（self-contained=${SELF_CONTAINED}）…"
 rm -rf "$PUBLISH_DIR"
 "$DOTNET" publish "$CSPROJ" -r "$RID" -c Release --self-contained "$SELF_CONTAINED"
 
-echo "==> 组装 $OUT …"
-rm -rf "$OUT"; mkdir -p "$OUT"
-cp -R "$PUBLISH_DIR/." "$OUT/"
-# 移除运行期生成的目录（若上次在 publish 目录跑过）
-rm -rf "$OUT/config" "$OUT/debug" "$OUT/temp" "$OUT/backup"
+# 把 publish 产物 + 资源组装到 $stage
+stage_payload() {
+    local dest="$1"
+    mkdir -p "$dest"
+    cp -R "$PUBLISH_DIR/." "$dest/"
+    rm -rf "$dest/config" "$dest/debug" "$dest/temp" "$dest/backup"
+    mkdir -p "$dest/assets"
+    cp "$ROOT/assets/interface.json" "$dest/assets/interface.json"
+    cp -R "$ROOT/assets/resource" "$dest/assets/resource"
+    rm -rf "$dest/assets/resource/config" "$dest/assets/resource/temp" \
+           "$dest/assets/resource/backup" "$dest/assets/resource/base/image/unused"
+    [ -d "$dest/MaaAgentBinary" ] && [ -d "$dest/libs/MaaAgentBinary" ] && rm -rf "$dest/MaaAgentBinary"
+    cp "$ROOT/README.md" "$dest/" 2>/dev/null || true
+    cp "$ROOT/LICENSE" "$dest/" 2>/dev/null || true
+    chmod +x "$dest/MATR" 2>/dev/null || true
+}
 
-# 铺入游戏资源（不在 publish 产物中，需手动拷贝，与 pack.ps1 一致）
-mkdir -p "$OUT/assets"
-cp "$ROOT/assets/interface.json" "$OUT/assets/interface.json"
-cp -R "$ROOT/assets/resource" "$OUT/assets/resource"
-# 剔除开发期/个人数据资源子目录（与 pack.ps1 一致）
-rm -rf "$OUT/assets/resource/config" "$OUT/assets/resource/temp" \
-       "$OUT/assets/resource/backup" "$OUT/assets/resource/base/image/unused"
+# 由 PNG 生成 .icns（缺 logo 时跳过）
+make_icns() {
+    local src="$1" dst="$2"
+    [ -f "$src" ] || return 1
+    local tmp iconset
+    tmp="$(mktemp -d)"; iconset="$tmp/MATR.iconset"; mkdir -p "$iconset"
+    local sz
+    for sz in 16 32 64 128 256 512; do
+        sips -z "$sz" "$sz" "$src" --out "$iconset/icon_${sz}x${sz}.png" >/dev/null 2>&1
+        sips -z "$((sz*2))" "$((sz*2))" "$src" --out "$iconset/icon_${sz}x${sz}@2x.png" >/dev/null 2>&1
+    done
+    iconutil -c icns "$iconset" -o "$dst" >/dev/null 2>&1
+    local rc=$?; rm -rf "$tmp"; return $rc
+}
 
-# 代理二进制在运行期从 libs/MaaAgentBinary 解析；若同时存在根部冗余副本则移除
-[ -d "$OUT/MaaAgentBinary" ] && [ -d "$OUT/libs/MaaAgentBinary" ] && rm -rf "$OUT/MaaAgentBinary"
-
-cp "$ROOT/README.md" "$OUT/" 2>/dev/null || true
-cp "$ROOT/LICENSE" "$OUT/" 2>/dev/null || true
-chmod +x "$OUT/MATR" 2>/dev/null || true
-
-echo "==> 完成：$OUT"
-if [ "$SELF_CONTAINED" = false ]; then
-    echo "    框架依赖构建：需要已安装 .NET 10 运行时。"
-    echo "    dotnet 不在 PATH 时可用： DOTNET_ROOT=\"\$HOME/.dotnet\" \"$OUT/MATR\""
-    echo "    或运行 \"$OUT/DependencySetup_依赖库安装_mac.sh\" 安装 .NET 10 运行时。"
+if [ "$APP" = false ]; then
+    echo "==> 组装 $OUT …"
+    rm -rf "$OUT"
+    stage_payload "$OUT"
+    RESULT="$OUT"
 else
-    echo "    自包含构建：直接运行 →  \"$OUT/MATR\""
+    APPDIR="$ROOT/MATR.app"
+    echo "==> 组装应用包 $APPDIR …"
+    rm -rf "$APPDIR"
+    mkdir -p "$APPDIR/Contents/MacOS" "$APPDIR/Contents/Resources"
+    stage_payload "$APPDIR/Contents/MacOS"
+    if make_icns "$LOGO" "$APPDIR/Contents/Resources/MATR.icns"; then
+        ICON_LINE="    <key>CFBundleIconFile</key><string>MATR</string>"
+    else
+        echo "    （未找到 logo，跳过图标）"; ICON_LINE=""
+    fi
+    cat > "$APPDIR/Contents/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key><string>MATR</string>
+    <key>CFBundleDisplayName</key><string>MATR</string>
+    <key>CFBundleIdentifier</key><string>com.notzoruak.matr</string>
+    <key>CFBundleVersion</key><string>${VERSION}</string>
+    <key>CFBundleShortVersionString</key><string>${VERSION}</string>
+    <key>CFBundleExecutable</key><string>MATR</string>
+${ICON_LINE}
+    <key>CFBundlePackageType</key><string>APPL</string>
+    <key>CFBundleInfoDictionaryVersion</key><string>6.0</string>
+    <key>LSMinimumSystemVersion</key><string>11.0</string>
+    <key>NSHighResolutionCapable</key><true/>
+    <key>LSApplicationCategoryType</key><string>public.app-category.utilities</string>
+</dict>
+</plist>
+PLIST
+    RESULT="$APPDIR"
+fi
+
+echo "==> 完成：$RESULT"
+if [ "$APP" = true ]; then
+    if [ "$SELF_CONTAINED" = true ]; then
+        echo "    双击 MATR.app 即可运行（自包含，无需安装 .NET）。"
+    else
+        echo "    双击 MATR.app 运行；框架依赖，需已安装 .NET 10 运行时。"
+    fi
+    echo "    首次打开若被 Gatekeeper 拦截：右键 → 打开（未签名/未公证的正常提示），"
+    echo "    或执行： xattr -dr com.apple.quarantine \"$RESULT\""
+elif [ "$SELF_CONTAINED" = false ]; then
+    echo "    框架依赖构建：需已安装 .NET 10 运行时。"
+    echo "    dotnet 不在 PATH 时： DOTNET_ROOT=\"\$HOME/.dotnet\" \"$RESULT/MATR\""
+else
+    echo "    自包含：直接运行 →  \"$RESULT/MATR\""
 fi
 
 if [ "$ZIP" = true ]; then
-    echo "==> 压缩…"
-    ( cd "$ROOT" && rm -f "MATR-$VERSION-$RID.zip" \
-        && ditto -c -k --sequesterRsrc --keepParent "$OUT" "MATR-$VERSION-$RID.zip" )
-    echo "    压缩包：$ROOT/MATR-$VERSION-$RID.zip"
+    ZIP_NAME="MATR-$VERSION-$RID.zip"
+    echo "==> 压缩 $ZIP_NAME …"
+    ( cd "$ROOT" && rm -f "$ZIP_NAME" \
+        && ditto -c -k --sequesterRsrc --keepParent "$RESULT" "$ZIP_NAME" )
+    echo "    压缩包：$ROOT/$ZIP_NAME"
 fi

--- a/tools/pack_mac.sh
+++ b/tools/pack_mac.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# macOS 打包脚本（tools/pack.ps1 的 macOS 等价物）。
+# 将 `dotnet publish` 产物与游戏资源（assets/interface.json + assets/resource）
+# 组装成一个可直接运行的文件夹 MATR-<版本>-<RID>/，内含原生可执行文件 ./MATR。
+#
+# 用法：
+#   tools/pack_mac.sh [版本] [--self-contained] [--zip]
+#     版本            输出目录/压缩包名中的版本号（默认 dev）
+#     --self-contained 打包自包含 .NET 运行时（免装/免设 DOTNET_ROOT，体积更大）
+#     --zip           额外产出 MATR-<版本>-<RID>.zip
+# 环境变量：
+#   RID     目标运行时（默认 osx-arm64，可设 osx-x64）
+#   DOTNET  dotnet 可执行文件（默认 dotnet；SDK 装在 ~/.dotnet 时设 DOTNET="$HOME/.dotnet/dotnet"）
+#
+set -euo pipefail
+
+VERSION="dev"
+SELF_CONTAINED=false
+ZIP=false
+for arg in "$@"; do
+    case "$arg" in
+        --self-contained) SELF_CONTAINED=true ;;
+        --zip) ZIP=true ;;
+        -*) echo "未知选项：$arg" >&2; exit 2 ;;
+        *) VERSION="$arg" ;;
+    esac
+done
+
+RID="${RID:-osx-arm64}"
+DOTNET="${DOTNET:-dotnet}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CSPROJ="$ROOT/_src/MFAAvalonia.Desktop/MFAAvalonia.Desktop.csproj"
+PUBLISH_DIR="$ROOT/_src/bin/AnyCPU/Release/$RID/publish"
+OUT="$ROOT/MATR-$VERSION-$RID"
+
+command -v "$DOTNET" >/dev/null 2>&1 || { echo "找不到 dotnet（可用 DOTNET=/path/to/dotnet 指定）" >&2; exit 1; }
+
+echo "==> 发布 ${RID}（self-contained=${SELF_CONTAINED}）…"
+rm -rf "$PUBLISH_DIR"
+"$DOTNET" publish "$CSPROJ" -r "$RID" -c Release --self-contained "$SELF_CONTAINED"
+
+echo "==> 组装 $OUT …"
+rm -rf "$OUT"; mkdir -p "$OUT"
+cp -R "$PUBLISH_DIR/." "$OUT/"
+# 移除运行期生成的目录（若上次在 publish 目录跑过）
+rm -rf "$OUT/config" "$OUT/debug" "$OUT/temp" "$OUT/backup"
+
+# 铺入游戏资源（不在 publish 产物中，需手动拷贝，与 pack.ps1 一致）
+mkdir -p "$OUT/assets"
+cp "$ROOT/assets/interface.json" "$OUT/assets/interface.json"
+cp -R "$ROOT/assets/resource" "$OUT/assets/resource"
+# 剔除开发期/个人数据资源子目录（与 pack.ps1 一致）
+rm -rf "$OUT/assets/resource/config" "$OUT/assets/resource/temp" \
+       "$OUT/assets/resource/backup" "$OUT/assets/resource/base/image/unused"
+
+# 代理二进制在运行期从 libs/MaaAgentBinary 解析；若同时存在根部冗余副本则移除
+[ -d "$OUT/MaaAgentBinary" ] && [ -d "$OUT/libs/MaaAgentBinary" ] && rm -rf "$OUT/MaaAgentBinary"
+
+cp "$ROOT/README.md" "$OUT/" 2>/dev/null || true
+cp "$ROOT/LICENSE" "$OUT/" 2>/dev/null || true
+chmod +x "$OUT/MATR" 2>/dev/null || true
+
+echo "==> 完成：$OUT"
+if [ "$SELF_CONTAINED" = false ]; then
+    echo "    框架依赖构建：需要已安装 .NET 10 运行时。"
+    echo "    dotnet 不在 PATH 时可用： DOTNET_ROOT=\"\$HOME/.dotnet\" \"$OUT/MATR\""
+    echo "    或运行 \"$OUT/DependencySetup_依赖库安装_mac.sh\" 安装 .NET 10 运行时。"
+else
+    echo "    自包含构建：直接运行 →  \"$OUT/MATR\""
+fi
+
+if [ "$ZIP" = true ]; then
+    echo "==> 压缩…"
+    ( cd "$ROOT" && rm -f "MATR-$VERSION-$RID.zip" \
+        && ditto -c -k --sequesterRsrc --keepParent "$OUT" "MATR-$VERSION-$RID.zip" )
+    echo "    压缩包：$ROOT/MATR-$VERSION-$RID.zip"
+fi


### PR DESCRIPTION
# Pull Request

提交前请阅读 [PR 规范](../docs/zh_cn/develop/pull_request_guidelines.md)。

## 关联 Issue

无关联 Issue。需求来源：为 MATR 增加 macOS（优先 Apple Silicon）支持，让 macOS 用户可通过 ADB 模拟器（如 BlueStacks Air）完成与 Windows 基本一致的自动化。

## 变更摘要

- **支持 osx-arm64 构建与运行**：非 Windows 上禁用 NetBeauty（其 `BeautyLibsDir` 的 `;` 在 POSIX shell 下被当作命令分隔符导致发布失败），并让 MaaAgentBinary 路径回退查找（`runtimes/libs → libs → 根目录`），使 minitouch/maatouch 输入可用。
- **平台条件化（不改 Windows 行为）**：`Desktop.csproj` 的 `OutputType`/`Platforms`/`ApplicationManifest`/`ApplicationIcon` 按 `$(OS)` 区分；`Program.cs` 的 Python venv 路径按平台选择（Windows `Scripts/python.exe`，类 Unix `bin/python`）。
- **修复 macOS 中文方框（□）**：新增应用级 CJK 字体回退（Microsoft YaHei / PingFang SC / Noto Sans CJK SC）。
- **修复「常规/全局」切换文字重叠**：见下方评审说明。
- **macOS 打包**：新增 `tools/pack_mac.sh`，可产出可运行文件夹或双击即用的自包含 `MATR.app`（含自动生成图标）。
- **默认下载源改为 GitHub**（原为 Mirror酱；仅影响未设置过的新配置）。

## 验证

在 Apple Silicon（arm64）+ .NET 10.0.400 + BlueStacks Air 实测：
- `dotnet build/publish -r osx-arm64` 0 错误；`MATR.app` 在**完全无 .NET 的干净环境**下双击启动正常。
- 完整链路打通：GUI 启动 → MaaFramework 初始化 → 资源加载（v0.12.2）→ ADB 自动发现并连接 BlueStacks → 截图 / 识图 / OCR → 输入（MaaTouch）→ 实测「刷花」任务点击/滑动正常。
- 中文方框、常规/全局 重叠均逐帧截图确认修复。

- [x] 我已阅读并遵守 [PR 规范](../docs/zh_cn/develop/pull_request_guidelines.md)

## 截图 / 日志 / 说明